### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -8,7 +8,6 @@
 (define categories '(devtools))
 (define primary-file "tool.rkt")
 
-(define deps '("base" "gui-lib" "data-lib" "drracket-plugin-lib"
-               "unstable-list-lib"))
+(define deps '("base" "gui-lib" "data-lib" "drracket-plugin-lib"))
 (define single-collection "drracket-vim-tool")
 

--- a/private/text.rkt
+++ b/private/text.rkt
@@ -4,7 +4,7 @@
          data/queue
          framework
          racket/control
-         unstable/function)
+         racket/function)
 
 (define on-local-char/c
   (->m (is-a?/c key-event%) void?))


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
